### PR TITLE
User configurable readonly setting for Find Results view

### DIFF
--- a/BetterFindBuffer.sublime-settings
+++ b/BetterFindBuffer.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "readonly": true
+}

--- a/FindResults.hidden-tmTheme
+++ b/FindResults.hidden-tmTheme
@@ -10,22 +10,22 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#ffffff</string>
+				<string>#000000</string>
 				<key>foreground</key>
-				<string>#444444</string>
+				<string>#ffffff</string>
 
 				<key>caret</key>
-				<string>#FF55FF</string>
+				<string>#f68c06</string>
 				<key>invisibles</key>
 				<string>#44444466</string>
 
 				<key>lineHighlight</key>
-				<string>#00000022</string>
+				<string>#1f1f1f</string>
 
 				<key>selection</key>
-				<string>#ffff00</string>
+				<string>#afafaf</string>
 				<key>selectionBorder</key>
-				<string>#ffff00</string>
+				<string>#3f3f3f</string>
 				<key>selectionForeground</key>
 				<string>#000000</string>
 
@@ -51,7 +51,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#660099</string>
+				<string>#00ffff</string>
 				<key>fontStyle</key>
 				<string>bold</string>
 			</dict>
@@ -75,7 +75,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#009121</string>
+				<string>#f68c06</string>
 				<key>fontStyle</key>
 				<string>bold</string>
 			</dict>
@@ -87,7 +87,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#660099</string>
+				<string>#f68c06</string>
 				<key>fontStyle</key>
 				<string>bold</string>
 			</dict>
@@ -99,7 +99,7 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#44444433</string>
+				<string>#0fa1e0</string>
 			</dict>
 		</dict>
 
@@ -109,7 +109,7 @@
 			<key>settings</key>
 			<dict>
 				<key>background</key>
-				<string>#FFD42044</string>
+				<string>#1f1f1f</string>
 			</dict>
 		</dict>
 
@@ -120,9 +120,9 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#444444</string>
+				<string>#0fa1e0</string>
 				<key>background</key>
-				<string>#FFD42066</string>
+				<string>#1f1f1f</string>
 			</dict>
 		</dict>
 
@@ -132,9 +132,9 @@
 			<key>settings</key>
 			<dict>
 				<key>foreground</key>
-				<string>#FFD42044</string>
+				<string>#0a709c</string>
 				<key>background</key>
-				<string>#FFD42044</string>
+				<string>#1f1f1f</string>
 			</dict>
 		</dict>
 
@@ -147,7 +147,7 @@
 				<key>foreground</key>
 				<string>#ffffff</string>
 				<key>background</key>
-				<string>#80a0ff</string>
+				<string>#26304c</string>
 				<key>fontStyle</key>
 				<string>bold</string>
 			</dict>

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -16,16 +16,31 @@
                             {
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/BetterFindBuffer/Find Results.sublime-settings"
+                                    "file": "${packages}/BetterFindBuffer/BetterFindBuffer.sublime-settings"
                                 },
                                 "caption": "Settings – Default"
                             },
                             {
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/User/Find Results.sublime-settings"
+                                    "file": "${packages}/User/BetterFindBuffer.sublime-settings"
                                 },
                                 "caption": "Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/BetterFindBuffer/Find Results.sublime-settings"
+                                },
+                                "caption": "Find Results Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/Find Results.sublime-settings"
+                                },
+                                "caption": "Find Results Settings – User"
                             }
                         ]
                     }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,36 @@
+[
+    {
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "BetterFindBuffer",
+                        "children":
+                        [
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/BetterFindBuffer/Find Results.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/Find Results.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/find_results.py
+++ b/find_results.py
@@ -63,11 +63,26 @@ class FindInFilesSetReadOnly(sublime_plugin.EventListener):
 
     def on_activated_async(self, view):
         if self.is_find_results(view):
-            view.set_read_only(True)
+            # Get user preference for setting view as read only
+            settings = sublime.load_settings('BetterFindBuffer.sublime-settings')
+            readonly = True
+            if settings:
+                readonly = settings.get('readonly', True)
+            view.set_read_only(readonly)
 
     def on_deactivated_async(self, view):
         if self.is_find_results(view):
             view.set_read_only(False)
+
+
+# Some plugins like **Color Highlighter** are forcing their color-scheme to the activated view
+# Although, it's something that should be fixed on their side, in the meantime, it's safe to force
+# the color shceme on `on_activated_async` event.
+class BFBForceColorSchemeCommand(sublime_plugin.EventListener):
+    def on_activated_async(self, view):
+        syntax = view.settings().get('syntax')
+        if syntax and (syntax.endswith("Find Results.hidden-tmLanguage")):
+            view.settings().set('color_scheme','Packages/BetterFindBuffer/FindResults.hidden-tmTheme')
 
 
 def plugin_loaded():


### PR DESCRIPTION
Hi,
I've made the readonly setting for the Find Results view user configurable. Also added Preferences menu entries for viewing the User and Default settings. 

There are two different settings files, `Find Results.sublime-settings` for the existing settings that affect the Find Results display (this is unchanged), and a new one `BetterFindBuffer.sublime-settings` for the new `readonly` setting.