### PR TITLE
User configurable readonly setting for Find Results view

### DIFF
--- a/BetterFindBuffer.sublime-settings
+++ b/BetterFindBuffer.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "readonly": true
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,51 @@
+[
+    {
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "BetterFindBuffer",
+                        "children":
+                        [
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/BetterFindBuffer/BetterFindBuffer.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/BetterFindBuffer.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/BetterFindBuffer/Find Results.sublime-settings"
+                                },
+                                "caption": "Find Results Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/Find Results.sublime-settings"
+                                },
+                                "caption": "Find Results Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/find_results.py
+++ b/find_results.py
@@ -65,9 +65,7 @@ class FindInFilesSetReadOnly(sublime_plugin.EventListener):
         if self.is_find_results(view):
             # Get user preference for setting view as read only
             settings = sublime.load_settings('BetterFindBuffer.sublime-settings')
-            readonly = True
-            if settings:
-                readonly = settings.get('readonly', True)
+            readonly = settings.get('readonly', True) if settings else True
             view.set_read_only(readonly)
 
     def on_deactivated_async(self, view):

--- a/find_results.py
+++ b/find_results.py
@@ -70,6 +70,16 @@ class FindInFilesSetReadOnly(sublime_plugin.EventListener):
             view.set_read_only(False)
 
 
+# Some plugins like **Color Highlighter** are forcing their color-scheme to the activated view
+# Although, it's something that should be fixed on their side, in the meantime, it's safe to force
+# the color shceme on `on_activated_async` event.
+class BFBForceColorSchemeCommand(sublime_plugin.EventListener):
+    def on_activated_async(self, view):
+        syntax = view.settings().get('syntax')
+        if syntax and (syntax.endswith("Find Results.hidden-tmLanguage")):
+            view.settings().set('color_scheme','Packages/BetterFindBuffer/FindResults.hidden-tmTheme')
+
+
 def plugin_loaded():
     default_package_path = os.path.join(sublime.packages_path(), "Default")
 

--- a/find_results.py
+++ b/find_results.py
@@ -63,7 +63,12 @@ class FindInFilesSetReadOnly(sublime_plugin.EventListener):
 
     def on_activated_async(self, view):
         if self.is_find_results(view):
-            view.set_read_only(True)
+            # Get user preference for setting view as read only
+            settings = sublime.load_settings('BetterFindBuffer.sublime-settings')
+            readonly = True
+            if settings:
+                readonly = settings.get('readonly', True)
+            view.set_read_only(readonly)
 
     def on_deactivated_async(self, view):
         if self.is_find_results(view):


### PR DESCRIPTION
Hi,
I've made the readonly setting for the Find Results view user configurable. Also added Preferences menu entries for viewing the User and Default settings.

There are two different settings files, `Find Results.sublime-settings` for the existing settings that affect the Find Results display (this is unchanged), and a new one `BetterFindBuffer.sublime-settings` for the new `readonly` setting.