### PR TITLE
Minor syntax highlighting fixes

### DIFF
--- a/Find Results.hidden-tmLanguage
+++ b/Find Results.hidden-tmLanguage
@@ -116,6 +116,34 @@
 			</dict>
 		</dict>
 
+		<dict>
+			<key>match</key>
+			<string>^(0) matches\n</string>
+			<key>name</key>
+			<string>footer.find-in-files</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.no_matches.find-in-files</string>
+				</dict>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>match</key>
+			<string>^(0) matches</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>variable.no_matches.find-in-files</string>
+				</dict>
+			</dict>
+		</dict>
+
 	</array>
 	<key>scopeName</key>
 	<string>text.find-in-files</string>

--- a/Find Results.hidden-tmLanguage
+++ b/Find Results.hidden-tmLanguage
@@ -73,7 +73,7 @@
 
 		<dict>
 			<key>match</key>
-			<string>^Searching (\d+) files for (".+")(.+)?$</string>
+			<string>^Searching (\d+) file(?:s)? for (".+")(.+)?$</string>
 			<key>name</key>
 			<string>header.find-in-files</string>
 			<key>captures</key>

--- a/FindResults.hidden-tmTheme
+++ b/FindResults.hidden-tmTheme
@@ -95,6 +95,18 @@
 
 		<dict>
 			<key>scope</key>
+			<string>variable.no_matches.find-in-files</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff0000</string>
+				<key>fontStyle</key>
+				<string>bold</string>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>scope</key>
 			<string>constant.numeric.line-number.find-in-files</string>
 			<key>settings</key>
 			<dict>


### PR DESCRIPTION
This applies the `header.find-in-files` scope to the header when searching only one file and the `footer.find-in-files` scope to the footer when there is no matches.

It also adds the `variable.no_matches.find-in-files` scope to highlight differently the number of matches when there are none.