### PR TITLE
Don’t force the default color scheme

### DIFF
--- a/find_results.py
+++ b/find_results.py
@@ -70,6 +70,16 @@ class FindInFilesSetReadOnly(sublime_plugin.EventListener):
             view.set_read_only(False)
 
 
+# Some plugins like **Color Highlighter** are forcing their color-scheme to the activated view
+# Although, it's something that should be fixed on their side, in the meantime, it's safe to force
+# the color shceme on `on_activated_async` event.
+class BFBForceColorSchemeCommand(sublime_plugin.EventListener):
+    def on_activated_async(self, view):
+        syntax = view.settings().get('syntax')
+        if syntax and (syntax.endswith("Find Results.hidden-tmLanguage")):
+            view.settings().set('color_scheme','Packages/BetterFindBuffer/FindResults.hidden-tmTheme')
+
+
 def plugin_loaded():
     default_package_path = os.path.join(sublime.packages_path(), "Default")
 

--- a/find_results.py
+++ b/find_results.py
@@ -77,7 +77,10 @@ class BFBForceColorSchemeCommand(sublime_plugin.EventListener):
     def on_activated_async(self, view):
         syntax = view.settings().get('syntax')
         if syntax and (syntax.endswith("Find Results.hidden-tmLanguage")):
-            view.settings().set('color_scheme','Packages/BetterFindBuffer/FindResults.hidden-tmTheme')
+            settings = sublime.load_settings('Find Results.sublime-settings')
+            color_scheme = settings.get('color_scheme')
+            if color_scheme:
+                view.settings().set('color_scheme', color_scheme)
 
 
 def plugin_loaded():


### PR DESCRIPTION
This prevents the compatibility fix with Color Highlighter to override the user’s custom color scheme.

Fixes #15.